### PR TITLE
Updated README with a more flexible example Gruntfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 If you haven't used [Grunt](http://gruntjs.com/) before, be sure to check out the [Getting Started](http://gruntjs.com/getting-started) guide, as it explains how to create a [Gruntfile](http://gruntjs.com/sample-gruntfile) as well as install and use Grunt plugins. Once you're familiar with that process, you may install this plugin with this command:
 
 ```shell
-npm install grunt-screeps 
+npm install grunt-screeps
 ```
 
 ### Usage Example
@@ -18,11 +18,12 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-screeps');
 
     grunt.initConfig({
+        creds: grunt.file.readJSON('config/screeps-creds.json'),
         screeps: {
             options: {
-                email: 'YOUR_EMAIL',
-                password: 'YOUR_PASSWORD',
-                branch: 'default',
+                email: '<%= creds.email %>',
+                password: '<%= creds.password %>',
+                branch: grunt.option('branch') || 'default',
                 ptr: false
             },
             dist: {
@@ -30,10 +31,34 @@ module.exports = function(grunt) {
             }
         }
     });
+};
+```
+
+#### Screep credentials
+
+Add a new file to your project: `config/screeps-creds.json`
+
+```
+{
+  "email": "<Your Email>",
+  "password": "<Your Password>"
 }
 ```
 
-Now you can run this command to commit your code from `dist` folder to your Screeps account:
+Ensure that file is added to your `.gitignore` file to avoid committing your credentials to GitHub.
+
+#### Deploy to Screeps
+
+Now you can run this command to deploy your code from `dist` folder to the `default` branch on your Screeps account:
+
 ```
 grunt screeps
 ```
+
+Or, to deploy to a specific branch:
+
+```
+grunt screeps --branch=mybranch
+```
+
+Note: You must create the branch on Screeps first before you can deploy to it

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Add a new file to your project: `config/screeps-creds.json`
 }
 ```
 
-Ensure that file is added to your `.gitignore` file to avoid committing your credentials to GitHub.
+Ensure that this file is added to your `.gitignore` file to avoid committing your credentials to GitHub.
 
 #### Deploy to Screeps
 


### PR DESCRIPTION
Great plugin, I'm planning to use it to deploy my screeps project.

However, I thought your suggested `Gruntfile` could be improved to be more flexible and more secure by avoiding committing people's Screeps login credentials to GitHub.

With these suggestions, users can put read their credentials from `config/screeps-creds.json`, which can be `gitignored` to avoid committing their credentials to source control.

Also by reading cli options from Grunt, you can deploy to a specific branch on screeps instead of only `default`.
