### PR TITLE
Can now optionally configure a private API server via screeps.options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 npm-debug.log
 tmp
+.idea

--- a/README.md
+++ b/README.md
@@ -37,3 +37,36 @@ Now you can run this command to commit your code from `dist` folder to your Scre
 ```
 grunt screeps
 ```
+
+### Private Server Usage Example
+
+**Gruntfile.js:**
+```js
+module.exports = function(grunt) {
+
+    grunt.loadNpmTasks('grunt-screeps');
+
+    grunt.initConfig({
+        screeps: {
+            options: {
+                server: {
+                    host: 'your.server.hostname.or.ip',
+                    port: 21025,
+                    http: true
+                },
+                email: 'YOUR_EMAIL',
+                password: 'YOUR_PASSWORD',
+                branch: 'default',
+                ptr: false
+            },
+            dist: {
+                src: ['dist/*.js']
+            }
+        }
+    });
+}
+```
+
+The above example is confirmed to work with a server running on the default
+port 21025 with the
+[screepsmod-auth](https://github.com/ScreepsMods/screepsmod-auth) mod enabled.

--- a/README.md
+++ b/README.md
@@ -38,35 +38,4 @@ Now you can run this command to commit your code from `dist` folder to your Scre
 grunt screeps
 ```
 
-### Private Server Usage Example
-
-**Gruntfile.js:**
-```js
-module.exports = function(grunt) {
-
-    grunt.loadNpmTasks('grunt-screeps');
-
-    grunt.initConfig({
-        screeps: {
-            options: {
-                server: {
-                    host: 'your.server.hostname.or.ip',
-                    port: 21025,
-                    http: true
-                },
-                email: 'YOUR_EMAIL',
-                password: 'YOUR_PASSWORD',
-                branch: 'default',
-                ptr: false
-            },
-            dist: {
-                src: ['dist/*.js']
-            }
-        }
-    });
-}
-```
-
-The above example is confirmed to work with a server running on the default
-port 21025 with the
-[screepsmod-auth](https://github.com/ScreepsMods/screepsmod-auth) mod enabled.
+See more advanced usage examples in [this docs article](http://docs.screeps.com/contributed/advanced_grunt.html).


### PR DESCRIPTION
This adds [screepsmod-auth](https://github.com/ScreepsMods/screepsmod-auth) compatibility by using an optional `options.server` configuration similar to:

```js
server: {
    host: 'your.server.hostname.or.ip',
    port: 21025,
    http: true
}
```

Default values have not changed - it still uses `https://screeps.com:443` unless this is explicitly configured to do otherwise.