### PR TITLE
Update and clean up dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "grunt": "~0.4.5",
-    "grunt-contrib-clean": "^0.5.0",
-    "grunt-contrib-jshint": "^0.9.2",
-    "grunt-contrib-nodeunit": "^0.3.3",
+    "grunt": "^1.0.1",
+    "grunt-contrib-clean": "^1.0.0",
+    "grunt-contrib-jshint": "^1.1.0",
+    "grunt-contrib-nodeunit": "^1.0.0",
     "nock": "^0.59.1",
-    "underscore": "^1.7.0"
+    "nodeunit-httpclient": "^0.2.1"
   },
   "peerDependencies": {
     "grunt": ">=0.4.0"
@@ -42,13 +42,6 @@
     "test": "test"
   },
   "dependencies": {
-    "grunt": "^0.4.5",
-    "grunt-contrib-clean": "^0.5.0",
-    "grunt-contrib-jshint": "^0.9.2",
-    "nock": "^0.59.1",
-    "grunt-contrib-nodeunit": "^0.3.3",
-    "nodeunit-httpclient": "^0.2.1",
-    "underscore": "^1.7.0"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
The current release version of grunt-screeps has a lot of dependencies that aren't needed - the task itself only uses node built-in modules.    This removes all of the production dependencies, as well as updating the dev dependencies to the most recent versions.   The dev dependencies currently in use generate a lot of warnings during install.

Note:  I did not update the package version in package.json.