### PR TITLE
Auth token support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 If you haven't used [Grunt](http://gruntjs.com/) before, be sure to check out the [Getting Started](http://gruntjs.com/getting-started) guide, as it explains how to create a [Gruntfile](http://gruntjs.com/sample-gruntfile) as well as install and use Grunt plugins. Once you're familiar with that process, you may install this plugin with this command:
 
 ```shell
-npm install grunt-screeps 
+npm install grunt-screeps
 ```
 
 ### Usage Example
@@ -22,10 +22,15 @@ module.exports = function(grunt) {
     grunt.initConfig({
         screeps: {
             options: {
-                email: 'YOUR_EMAIL',
-                password: 'YOUR_PASSWORD',
+                accountAlias: 'LABEL_FOR_THIS_ACCOUNT',
                 branch: 'default',
-                ptr: false
+                ptr: false,
+                // token is used for the public server, will be preferred if
+                // both are provided.
+                token: 'YOUR_AUTH_TOKEN',
+                // email/password are used for private servers.
+                email: 'YOUR_EMAIL',
+                password: 'YOUR_PASSWORD'
             },
             dist: {
                 files: [

--- a/tasks/screeps.js
+++ b/tasks/screeps.js
@@ -52,17 +52,24 @@ module.exports = function (grunt) {
                 }
             });
 
-            var proto = server.http ? http : https,
-                req = proto.request({
+            const requestOptions = {
                 hostname: server.host || 'screeps.com',
                 port: server.port || (server.http ? 80 : 443),
                 path: options.ptr ? '/ptr/api/user/code' : '/api/user/code',
                 method: 'POST',
-                auth: options.email + ':' + options.password,
                 headers: {
                     'Content-Type': 'application/json; charset=utf-8'
                 }
-            }, function(res) {
+            };
+
+            if (options.token) {
+                requestOptions.headers['X-Token'] = options.token;
+            } else {
+                requestOptions.auth = options.email + ':' + options.password;
+            }
+
+            var proto = server.http ? http : https,
+                req = proto.request(requestOptions, function(res) {
                 res.setEncoding('utf8');
 
                 var data = '';
@@ -81,7 +88,7 @@ module.exports = function (grunt) {
                       var parsed = JSON.parse(data);
                       serverText = server && server.host || 'Screeps';
                       if(parsed.ok) {
-                          var msg = 'Committed to ' + serverText + ' account "' + options.email + '"';
+                          var msg = 'Committed to ' + serverText + ' account "' + options.accountAlias + '"';
                           if(options.branch) {
                               msg += ' branch "' + options.branch+'"';
                           }


### PR DESCRIPTION
This updates grunt-screeps to use the new auth tokens, removes email/password
completely, and adds a new accountAlias field.

I think that it'd be neat to be able to stream Screeps "gameplay" on Twitch,
but I don't like the idea of my username/email being displayed everytime I sync
my changes from development.

Using an account alias like 'main' or 'test' would be enough to identify which
account is being used without outputting any identifiable information.