### PR TITLE
Adding an extra server for screeps plus.

### DIFF
--- a/tasks/screeps.js
+++ b/tasks/screeps.js
@@ -17,7 +17,8 @@ var servers = {
     persistent: { name: 'Screeps', host: 'screeps.com', path: '/api/user/code' },
     ptr: { name: 'PTR', host: 'screeps.com', path: '/ptr/api/user/code' },
     season: { name: 'Season', host: 'screeps.com', path: '/season/api/user/code' },
-    plus : { name: 'Plus', host: 'server1.screepspl.us', path: '/api/user/code', port : '21025', http : true }
+    plus : { name: 'Plus', host: 'server1.screepspl.us', path: '/api/user/code', port : '21025', http : true },
+    swc : { name: 'SWC', host: 'swc.screepspl.us', path: '/api/user/code', port : '21025', http : true }
 };
 
 module.exports = function (grunt) {

--- a/tasks/screeps.js
+++ b/tasks/screeps.js
@@ -16,7 +16,8 @@ var path = require('path'),
 var servers = {
     persistent: { name: 'Screeps', host: 'screeps.com', path: '/api/user/code' },
     ptr: { name: 'PTR', host: 'screeps.com', path: '/ptr/api/user/code' },
-    season: { name: 'Season', host: 'screeps.com', path: '/season/api/user/code' }
+    season: { name: 'Season', host: 'screeps.com', path: '/season/api/user/code' },
+    plus : { name: 'Plus', host: 'server1.screepspl.us', path: '/api/user/code', port : '21025', http : true }
 };
 
 module.exports = function (grunt) {


### PR DESCRIPTION
Screeps plus does not use tokens (set to false). Has a different server and port. And uses your in game steam name instead of your email.

Also make sure that the screeps plus password from the screeps plus website matches your in game steam password.